### PR TITLE
Fix CLI for builds on Windows machines

### DIFF
--- a/cli/de.cau.cs.kieler.spviz.cli/src/de/cau/cs/kieler/spviz/cli/SPVizCLI.xtend
+++ b/cli/de.cau.cs.kieler.spviz.cli/src/de/cau/cs/kieler/spviz/cli/SPVizCLI.xtend
@@ -3,7 +3,7 @@
  *
  * http://rtsys.informatik.uni-kiel.de/kieler
  * 
- * Copyright 2024 by
+ * Copyright 2024-2025 by
  * + Kiel University
  *   + Department of Computer Science
  *   + Real-Time and Embedded Systems Group
@@ -20,6 +20,7 @@ import de.cau.cs.kieler.spviz.spvizmodel.SPVizModelStandaloneSetup
 import de.cau.cs.kieler.spviz.spvizmodel.generator.SPVizModelGenerator
 import java.io.BufferedReader
 import java.io.File
+import java.io.IOException
 import java.io.InputStreamReader
 import java.nio.file.Path
 import java.util.ArrayList
@@ -104,8 +105,8 @@ class SPVizCLI implements Runnable {
             SPVizModelStandaloneSetup.doSetup
             for (spvizModelFile : spvizModelFiles) {
                 // Parse the model file.
-                LOGGER.info("Generating sources for {}", spvizModelFile.absolutePath)
-                val Resource resource = rs.getResource(URI.createURI("file://" + spvizModelFile.absolutePath), true)
+                LOGGER.info("Generating sources for {}", spvizModelFile.absolutePath.replace("\\", "/"))
+                val Resource resource = rs.getResource(URI.createURI("file://" + spvizModelFile.absolutePath.replace("\\", "/")), true)
                 SPVizModelGenerator.generate(resource, output)
             }
             
@@ -114,21 +115,42 @@ class SPVizCLI implements Runnable {
             for (spvizFile : spvizFiles) {
                 // Parse the visualization file. A full absolute URI with file:// scheme is important, so that the resource
                 // can correctly resolve the imported .spvizmodel file.
-                LOGGER.info("Generating sources for {}", spvizFile.absolutePath)
-                val Resource resource = rs.createResource(URI.createURI("file://" + spvizFile.absolutePath))
+                LOGGER.info("Generating sources for {}", spvizFile.absolutePath.replace("\\", "/"))
+                val Resource resource = rs.createResource(URI.createURI("file://" + spvizFile.absolutePath.replace("\\", "/")))
                 resource.load(rs.getLoadOptions())
                 SPVizGenerator.generate(resource, output)
                 
                 // Build the project.
-                val buildProject = output.toAbsolutePath.toString + "/" + (resource.contents.head as SPViz).package + ".build"
+                val buildProject = output.toAbsolutePath.toString.replace("\\", "/") + "/" + (resource.contents.head as SPViz).package + ".build"
                 if (build) {
                     LOGGER.info("Building the project {}.", buildProject)
-                    #["mvn", "clean", "package"].invoke(new File(buildProject))
+                    try {
+	                    // First, try with "mvn" as the command
+	                    #["mvn", "clean", "package"].invoke(new File(buildProject))
+                    } catch (IOException e) try {
+                    	// If that does not work, try "mvn.cmd"
+                    	LOGGER.warn("Cannot invoke \"mvn\" command, trying \"mvn.cmd\" instead.")
+	                    #["mvn.cmd", "clean", "package"].invoke(new File(buildProject))
+                    	
+                    } catch (IOException e2) {
+           				LOGGER.error("Building generated project failed, because the \"mvn\" command cannot be executed. Is Maven installed and available via command line?. See trace for details.", e)
+                    }
+                    
                 }
                 // Build the generator.
                 if (buildGenerator) {
                     LOGGER.info("Building the project {}.", buildProject)
-                    #["mvn", "clean", "package", "-P", "generator"].invoke(new File(buildProject))
+                    try {
+	                    // First, try with "mvn" as the command
+                    	#["mvn", "clean", "package", "-P", "generator"].invoke(new File(buildProject))
+                	} catch (IOException e) try {
+                    	// If that does not work, try "mvn.cmd"
+                    	LOGGER.warn("Cannot invoke \"mvn\" command, trying \"mvn.cmd\" instead.")
+	                    #["mvn.cmd", "clean", "package", "-P", "generator"].invoke(new File(buildProject))
+                    	
+                    } catch (IOException e2) {
+           				LOGGER.error("Building generated project failed, because the \"mvn\" command cannot be executed. Is Maven installed and available via command line?. See trace for details.", e)
+                    }
                 }
             }
             LOGGER.info("SPViz project generation finished. The newly generated projects can be found in {}", output.toAbsolutePath().toString())
@@ -144,7 +166,7 @@ class SPVizCLI implements Runnable {
      * @param command The command to invoke, parameters in individual Strings in the list.
      * @param directory The root directory to execute the command.
      */
-    def invoke(List<String> command, File directory) {
+    def invoke(List<String> command, File directory) throws IOException {
         LOGGER.info("Invoking command: {}", command.join(" "))
         val pb = new ProcessBuilder(command)
         pb.directory(directory)
@@ -162,7 +184,10 @@ class SPVizCLI implements Runnable {
             
             LOGGER.info("Exit value: " + p.exitValue)
             return p.exitValue
-        } catch (Exception e) {
+        } catch (IOException io) {
+        	// re-throw IO exception
+        	throw io
+    	} catch (Exception e) {
             LOGGER.error("ERROR: Exception while invoking command", e)
         }
     }


### PR DESCRIPTION
Replace folder hierarchy \ with / for correct URI compatibility on Windows. For building with Maven and if the "mvn" command fails, try with the "mvn.cmd" command as well, which might be the default file in Windows instllations.